### PR TITLE
Added changes to make queryless parameters use "-" instead of "--"

### DIFF
--- a/SpotNetCore/SpotNetCore/Implementation/CommandHandler.cs
+++ b/SpotNetCore/SpotNetCore/Implementation/CommandHandler.cs
@@ -280,8 +280,8 @@ namespace SpotNetCore.Implementation
                 throw new ArgumentException("Input must contain command");
             }
             
-            var split = input.Split(new []{"--"}, StringSplitOptions.None);
-		
+            var split = input.Split(new[] { "-", "--" }, StringSplitOptions.RemoveEmptyEntries);
+
             return new ParsedCommand
             {
                 Command = split[0].Trim(),


### PR DESCRIPTION
Changes for making Queryless parameters use "-" instead of "--".

Example : queue -discography --artist system of a down -popular
Now gets split into a list of [ "queue", "discography", "artist system of a down ", "popular"]

Fixes https://github.com/Jessicaward/SpotNetCore/issues/62